### PR TITLE
Fix broken link with the magic of the Wayback Machine

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -181,7 +181,7 @@ gamelife.ro##[href="https://bit.ly/3Bwz1Tk"]
 ! substantial.ro
 ||noizz.ro^$third-party
 
-! https://github.com/BottledSoda/RoWebImprover/commit/cfa4b6c2bd7ffc69b018cfdead138fa723822013
+! https://web.archive.org/web/20220129164053/https://github.com/BottledSoda/RoWebImprover/commit/cfa4b6c2bd7ffc69b018cfdead138fa723822013
 libnet.ro#@##adblock
 libnet.ro##div.bnd
 libnet.ro##.row-header-baner


### PR DESCRIPTION
The link to https://github.com/BottledSoda/RoWebImprover/commit/cfa4b6c2bd7ffc69b018cfdead138fa723822013 is broken, as that repo no longer exists, meaning that the reference is lost.
However, that link exists in the Wayback Machine, so I have corrected it to be the archived version